### PR TITLE
Most tests now pass on windows

### DIFF
--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -18,18 +18,28 @@ exports.expectFilesToMatch = function(fileNameA, fileNameB) {
   var expected = utils.readFile(fileNameA);
   var actual = utils.readFile(fileNameB);
 
+  return exports.expectResultsToMatch(expected, actual);
+};
+
+/**
+ * Function: expectResultsToMatch
+ * ------------------------------
+ * Expects the results of the two given promises to match.
+ *
+ * @param expected - the first promise for a string or a string
+ * @param actual - the second promise for a string or a string
+ * 
+ * @return promise that yields success if the results match or an error
+ *  otherwise
+ */
+exports.expectResultsToMatch = function(expected, actual) {
   return q.all([expected, actual])
     .spread(function(expected, actual) {
       // make line-endings consistent
-      actual = actual.replace('\r\n', '\n');
-      expected = expected.replace('\r\n', '\n');
+      actual = actual.replace(/\r\n/g, '\n');
+      expected = expected.replace(/\r\n/g, '\n');
 
-      try {
-        actual.should.equal(expected);
-      } catch (error) {
-        // don't print out contents and expected because they are too large
-        throw new Error("Contents don't match expected.");
-      }
+      actual.should.equal(expected);
     });
 };
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -8,15 +8,15 @@ var q = require('q');
  * ----------------------------
  * Expects the contents of the two given files to match.
  *
- * @param fileNameA - the first file
- * @param fileNameB - the second file
+ * @param expectedFileName - the first file
+ * @param actualFileName - the second file
  * 
  * @return promise that yields success if the contents match or an error
  *  otherwise
  */
-exports.expectFilesToMatch = function(fileNameA, fileNameB) {
-  var expected = utils.readFile(fileNameA);
-  var actual = utils.readFile(fileNameB);
+exports.expectFilesToMatch = function(expectedFileName, actualFileName) {
+  var expected = utils.readFile(expectedFileName);
+  var actual = utils.readFile(actualFileName);
 
   return exports.expectResultsToMatch(expected, actual);
 };

--- a/test/test.fetch.js
+++ b/test/test.fetch.js
@@ -3,6 +3,7 @@ var urlLib = require('url');
 var q = require('q');
 var should = require('should');
 var utils = require('../lib/utils');
+var testUtils = require('./lib/utils');
 var libraries = require('../libraries.json');
 var sandboxedModule = require('sandboxed-module');
 
@@ -257,16 +258,10 @@ describe('`nodefront fetch`', function() {
     version = version || library.latest;
     var fileName = libraryName + '-' + version + '.' + extension;
 
-    // read contents of both input and expected
-    return utils.readFile(outputDir + '/' + fileName)
-      .then(function(contents) {
-        // compare and clean up
-        try {
-          contents.should.equal(expected);
-        } catch (error) {
-          // don't print out contents and expected because they are too large
-          throw new Error("Contents don't match expected.");
-        }
+    var actual = utils.readFile(outputDir + '/' + fileName);
+
+    return testUtils.expectResultsToMatch(expected, actual)
+      .then(function() {
         return q.ncall(fs.unlink, fs, outputDir + '/' + fileName);
       });
   }


### PR DESCRIPTION
I hadn't quite fixed the line ending issue in windows.  It needed to be a regular expression rather than a string.  I haven't managed to run the serve test yet (I need to get round to installing Python) but all the other tests except the following pass:

Compile leads to:

```
Error: ENOENT, unlink 
'C:\nodefront\test\resources\compile\input\layout.html'
```

Minify leads to:

```
Error: ENOENT, open
'C:\nodefront\test\resources\minify\input\images\book.min.jpg'
```

and

```
Error: ENOENT, open
'C:\nodefront\test\resources\minify\input\images\placeholder.min.png'
```
