### PR TITLE
Use the newer `transformers` instead of the deprecated `consolidate-build`

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var q = require('q');
 var pathLib = require('path');
-var build = require('consolidate-build');
+var build = require('transformers');
 var utils = require('../lib/utils');
 
 // files with these extensions need to be compiled;
@@ -234,7 +234,7 @@ function generateCompileFn(fileNameSansExtension, extension, compilerOptions,
     // simply use the file extension as a key
     return utils.mkdirRecursive(pathLib.dirname(directory + '/' + fileDisplay))
       .then(function() {
-        return q.ncall(build[extension], build[extension], fileName, options);
+        return build[extension].renderFile(fileName, options);
       })
       .then(function(output) {
         var newExtension = compiledExtensions[extension];

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coffee-script": ">= 1.3.2",
     "commander": "1.0.x",
     "commander-config": "0.x.x",
-    "consolidate-build": "1.x.x",
+    "transformers": "1.x.x",
     "jade": ">= 0.26.3",
     "mime": "1.2.x",
     "nconf": "0.6.x",


### PR DESCRIPTION
I'm about to deprecate `consolidate-build` in favor of the newer `transformers`.  It comes with:
- an optional promise based API
- additional transformations (such as `cson`
- magnification for JavaScript, CSS and JSON
- better error handling when appropriate engine is not installed
- output-format listings ('xml', 'css', 'js', 'json' or 'text')
- optional synchronous rendering where possible

I'm actively watching `consolidate` now and will continue to add new template libraries from `consolidate` but by not being tied to using it as a dependency I can more quickly fix failings in its implementations.
